### PR TITLE
perf: move regex compilation out of loop in RaydiumEvent::parse_logs

### DIFF
--- a/src/common/logs_events.rs
+++ b/src/common/logs_events.rs
@@ -67,10 +67,9 @@ impl RaydiumEvent {
 
         if !logs.is_empty() {
             let logs_iter = logs.iter().peekable();
+            let re = Regex::new(r"ray_log: (?P<base64>[A-Za-z0-9+/=]+)").unwrap();
 
             for l in logs_iter.rev() {
-                let re = Regex::new(r"ray_log: (?P<base64>[A-Za-z0-9+/=]+)").unwrap();
-
                 if let Some(caps) = re.captures(l) {
                     if let Some(base64) = caps.name("base64") {
                         let bytes = general_purpose::STANDARD.decode(base64.as_str()).unwrap();


### PR DESCRIPTION
# Optimize regex usage in RaydiumEvent::parse_logs

## Description
This PR improves the performance and correctness of the RaydiumEvent::parse_logs method by moving regex compilation outside of the loop.
The regex was previously compiled on every iteration, which is unnecessary and inefficient. It is now compiled once before the loop.

## Motivation
Regex compilation inside a loop can significantly impact performance, especially when parsing large logs.

## Impact
Improves runtime efficiency during log parsing.
No breaking API changes.